### PR TITLE
check for more possible request errors

### DIFF
--- a/fishbowl/api.py
+++ b/fishbowl/api.py
@@ -158,8 +158,10 @@ class Fishbowl:
             request = xmlrequests.SimpleRequest(request, value, key=self.key)
         root = self.send_message(request)
         if response_node_name:
-            root = root.find('FbiMsgsRs').find(response_node_name)
             try:
+                resp = root.find('FbiMsgsRs')
+                check_status(resp, allow_none=True)
+                root = resp.find(response_node_name)
                 check_status(root, allow_none=True)
             except FishbowlError:
                 if silence_errors:
@@ -295,8 +297,10 @@ class Fishbowl:
         :returns: A list of lazy :cls:`fishbowl.objects.Customer` objects
         """
         customers = []
-        request = self.send_request('CustomerNameListRq')
-        for tag in request.find('FbiMsgsRs').iter('Name'):
+        request = self.send_request(
+            'CustomerNameListRq', response_node_name='CustomerNameListRs',
+            single=False)
+        for tag in request.iter('Name'):
             get_customer = partial(
                 self.send_request, 'CustomerGetRq', {'Name': tag.text},
                 response_node_name='CustomerGetRs',


### PR DESCRIPTION
This seems to handle the error a little more appropriately. In the event of less specific errors on `FbiMsgsRs` in requests with `response_node_name` should actually raise that error, and `get_customer` should no longer swallow it. This should allow the calling code to decide how to handle it.

My practical test was still a bit artificial, but I think it's still accurate enough to prove it's fixed.

``` shell
In [1]: from fishbowl.api import Fishbowl

In [2]: f = Fishbowl()

In [3]: f.connect(username='quoteapp', password='hUM4n7ru$t90', host='192.168.20.10', port=28193)

In [4]: f.key = '123'

In [5]: f.get_customers()

### Before
Out[5]: []

### After
---------------------------------------------------------------------------
FishbowlError                             Traceback (most recent call last)
<ipython-input-5-92ec24640878> in <module>()
----> 1 f.get_customers()

/home/jsatt/dev/fishbowl-api/fishbowl/api.pyc in dec(self, *args, **kwargs)
     45         if not self.connected:
     46             raise OSError('Not connected')
---> 47         return func(self, *args, **kwargs)
     48
     49     return dec

/home/jsatt/dev/fishbowl-api/fishbowl/api.pyc in get_customers(self, silence_lazy_errors)
    300         request = self.send_request(
    301             'CustomerNameListRq', response_node_name='CustomerNameListRs',
--> 302             single=False)
    303         for tag in request.iter('Name'):
    304             get_customer = partial(

/home/jsatt/dev/fishbowl-api/fishbowl/api.pyc in dec(self, *args, **kwargs)
     45         if not self.connected:
     46             raise OSError('Not connected')
---> 47         return func(self, *args, **kwargs)
     48
     49     return dec

/home/jsatt/dev/fishbowl-api/fishbowl/api.pyc in send_request(self, request, value, response_node_name, single, silence_errors)
    161             try:
    162                 resp = root.find('FbiMsgsRs')
--> 163                 check_status(resp, allow_none=True)
    164                 root = resp.find(response_node_name)
    165                 check_status(root, allow_none=True)

/home/jsatt/dev/fishbowl-api/fishbowl/api.pyc in check_status(element, expected, allow_none)
    482         message = statuscodes.get_status(code)
    483     if code != expected and (code is not None or not allow_none):
--> 484         raise FishbowlError(message)
    485     return message

FishbowlError: Invalid ticket key passed to Fishbowl server.
```
